### PR TITLE
Adding CI Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  CRM_USERNAME: dummy-user
+  CRM_PASSWORD: dummy-password
+  PLAYWRIGHT_BROWSERS_PATH: '${{ github.workspace }}/pw-browsers'
+
+jobs:
+  test:
+    name: Playwright Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2]
+        shardTotal: [2]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Node.js Version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install Application Dependencies
+        run: yarn install --frozen-lockfile --prefer-offline
+
+      - name: Install Playwright Browsers & System Dependencies
+        run: |
+          yarn playwright install --with-deps chromium && \
+          echo "Listing $PLAYWRIGHT_BROWSERS_PATH:" && \
+          echo "---" && \
+          ls -al $PLAYWRIGHT_BROWSERS_PATH
+
+      - name: Run Tests
+        run: yarn run test:headless --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+      - name: Collecting Artifacts
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: shard-${{ matrix.shardIndex }}-playwright-report
+          path: |
+            playwright-report/
+            test-results/
+            test-results.xml
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -6,17 +6,13 @@ Playwright was created specifically to accommodate the needs of end-to-end testi
 
 ## Playwright vs Cypress
 
-?????
-
-https://www.browserstack.com/guide/playwright-vs-cypress
-
-- Testing Library style queries built into Playwright.
-- Playwright comes with an official [VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) that can trigger test runs and debug tests.
-- Writing tests is more akin to writing native scripts with the use of async/await and not having to rely on chaining and nested of commands like Cypress requires.
-- Playwright has first-class support for parallel running of tests on a single machine both locally and on CI without a subscription or account required.
+- Testing Library style queries built directly into Playwright where Cypress needs them added as a plugin.
+- Playwright comes with an official [VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) that can trigger test runs and act as a debugger.
+- Writing tests in Playwright is more like writing native scripts with the use of async/await. Cypress uses a command structure that relies on nesting and chaining and isn't as intuitive.
+- Playwright has first-class support for the parallel running of tests on a single machine both locally and on CI without using a paid solution. It can also run tests within the same file in parallel, where Cypress can only run entire test files in parallel. The official way to handle parallelism in Cypress is with a paid solution called [Cypress Cloud](https://cypress.io/cloud).
 - Playwright can re-run code blocks until attached assertion is true (via [Polling](https://playwright.dev/docs/test-assertions#polling) or [Retrying](https://playwright.dev/docs/test-assertions#retrying)).
-- Playwright supports multiple languages, including JavaScript, Java, Python, .NET, and C# where Cypress only supports JavaScript.
-- Playwright has built-in ability to [launch a process](https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests) and wait for a chosen port to respond before running tests.
+- Playwright supports tests being written in multiple languages including JavaScript, Java, Python, .NET, and C# where Cypress only supports JavaScript.
+- Playwright has built-in ability to [launch a process](https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests) and wait for a chosen port to respond before running tests. Cypress expects this to be handled externally.
 
 ## Debugging Tests
 
@@ -43,6 +39,8 @@ The traces, videos and screenshots will appear automatically linked to relevant 
 - [Assertions](https://playwright.dev/docs/test-assertions)
 - [Authentication](https://playwright.dev/docs/auth)
 - [Annotations](https://playwright.dev/docs/test-annotations)
+- [Command Line Tools](https://playwright.dev/docs/cli)
+- [Continuous Integration](https://playwright.dev/docs/ci)
 - [Debugging Tests](https://playwright.dev/docs/debug)
 - [Emulation](https://playwright.dev/docs/emulation)
 - [Environment Variables](https://playwright.dev/docs/test-parameterize#passing-environment-variables)
@@ -51,5 +49,4 @@ The traces, videos and screenshots will appear automatically linked to relevant 
 - [Screenshots](https://playwright.dev/docs/screenshots)
 - [Videos](https://playwright.dev/docs/videos)
 - [Example: Testing Multiple Roles](https://playwright.dev/docs/auth#testing-multiple-roles-together)
-
-- https://alisterbscott.com/2021/10/27/five-reasons-why-playwright-is-better-than-cypress/
+- [Research: Playwright vs Cypress](https://www.browserstack.com/guide/playwright-vs-cypress)

--- a/tests/environment-variables.spec.ts
+++ b/tests/environment-variables.spec.ts
@@ -12,7 +12,7 @@ test.describe('Environment variables', () => {
     await page
       .getByLabel(/username/i)
       .type(process.env.CRM_USERNAME, { delay: 75 });
-    console.log('now filling in the password...');
+
     await page
       .getByLabel(/password/i)
       .type(process.env.CRM_PASSWORD, { delay: 75 });
@@ -20,13 +20,6 @@ test.describe('Environment variables', () => {
     await page.getByRole('button', { name: /sign in/i }).click();
 
     await expect(page.getByText(/atomic crm/i)).toBeVisible();
-
-    const thingy = await page.evaluate(() => {
-      console.log('Hello World!');
-      return document.querySelector('#root');
-    });
-
-    console.log(thingy);
 
     await page.pause();
   });


### PR DESCRIPTION
Adding a CI workflow for pull requests and pushes to the trunk. The workflow has been configured to show how Playwright can be configured to install browsers to a custom location. A matrix has been configured to split the job into multiple jobs, passing shard information into Playwright to have tests run in parallel. Each job will upload that shards artifacts up to the overall job, correctly namespaced with the shard index to avoid collisions.

| Total Time Without Sharding | Total Time With Sharding |
| --- | --- |
| [2min 17secs](https://github.com/anthonyhastings/playwright-demo/actions/runs/3864393974) | [1min 17secs](https://github.com/anthonyhastings/playwright-demo/actions/runs/3869052304) |