### PR TITLE
Adding playwright UI mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@playwright/test": "^1.28.1",
+    "@playwright/test": "^1.32.1",
     "dotenv": "^16.0.3",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "show-report": "playwright show-report",
     "test:debug": "playwright test --debug",
-    "test:gui": "playwright test --headed",
+    "test:gui": "playwright test --ui",
     "test:headless": "playwright test",
     "test:tagged": "yarn run test:headless --grep @form"
   }

--- a/tests/form.spec.ts
+++ b/tests/form.spec.ts
@@ -100,13 +100,12 @@ test.describe('Form related interactions / assertions @form', () => {
   });
 
   test('Select controls (native) can be interacted with', async ({ page }) => {
-    await page.goto(
-      'https://interactive-examples.mdn.mozilla.net/pages/tabbed/select.html'
-    );
+    await page.goto('http://autopract.com/selenium/dropdown1/');
 
-    const dropdown = page.getByLabel(/choose a pet/i);
-    await dropdown.selectOption({ label: 'Hamster' });
-    await expect(dropdown).toHaveValue('hamster');
+    const dropdown = page.locator('select');
+    await expect(dropdown).toHaveValue('item1');
+    await dropdown.selectOption({ label: 'Table Tennis' });
+    await expect(dropdown).toHaveValue('item4');
   });
 
   test('Select controls (MUI) can be interacted with', async ({ page }) => {

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -25,7 +25,7 @@ test.describe('Page related assertions', () => {
     await expect(page).toHaveTitle('Installation | Playwright');
 
     await page.getByRole('link', { name: /^writing tests$/i }).click();
-    await expect(page).toHaveTitle('Writing Tests | Playwright');
+    await expect(page).toHaveTitle(/Writing Tests \| Playwright/i);
   });
 
   test('Triggers an alert within the page via a script', async ({ page }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,13 +7,15 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
   integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
 
-"@playwright/test@^1.28.1":
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
-  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
+"@playwright/test@^1.32.1":
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.32.1.tgz#749c9791adb048c266277a39ba0f7e33fe593ffe"
+  integrity sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.28.1"
+    playwright-core "1.32.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 "@types/node@*":
   version "18.11.10"
@@ -176,6 +178,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 get-stream@^6.0.1:
   version "6.0.1"
@@ -356,10 +363,10 @@ pidtree@^0.6.0:
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
-playwright-core@1.28.1:
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
-  integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
+playwright-core@1.32.1:
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.1.tgz#5a10c32403323b07d75ea428ebeed866a80b76a1"
+  integrity sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==
 
 prettier@^2.8.1:
   version "2.8.1"


### PR DESCRIPTION
As of [v1.32.0](https://github.com/microsoft/playwright/releases/tag/v1.32.0) Playwright now ships with a UI mode. This gives similar functionality to that of Cypress' GUI. As well as updating the package and passing the necessary CLI flag, this PR also fixes some broken tests.